### PR TITLE
Add Hermes to Voice, TTS & Cloning

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ Spokesperson and presenter video from a script — no camera, no studio.
 - [Hume](https://hume.ai) — emotion-aware voice (EVI) and expressive Octave TTS. 🔌
 - [Rime](https://rime.ai) — developer/enterprise TTS with sub-200ms latency. 🔌
 - [Resemble AI](https://resemble.ai) — enterprise voice cloning plus deepfake detection. 🔌 🧩
+- [Hermes](https://buildwithhermes.com) — operating platform for running an AI voice-agent business solo: white-label phone agents with built-in CRM, campaigns, and client billing, from $149/mo.
 - [OmniVoice Studio](https://github.com/debpalash/OmniVoice-Studio) — open-source, fully-local ElevenLabs alternative: voice cloning, dubbing, dictation, 646 languages, no API keys. 🆓 🔓
 
 ## Music & Sound Effects


### PR DESCRIPTION
Adds Hermes (buildwithhermes.com) to the Voice, TTS & Cloning section.

Why it fits this list: a common solo-builder business in 2026 is running AI phone agents for local businesses. The current voice entries cover the speech layer (TTS, cloning). Hermes covers the business layer on top: one person can deploy white-label voice agents, run outbound/inbound campaigns, manage client contacts, and bill clients, without hiring a team or stitching 5 tools together. Plans from $149/mo with included minutes.

Matched your entry format and separator style. Happy to move it to another section or trim the line if you prefer.