### PR TITLE
Add marketing, SEO and social from Claude page

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,6 +266,7 @@ Building is half the job — this is how a solo builder gets users. **Where to l
 - [Peerlist](https://peerlist.io) — launchpad and network for builders.
 
 **Grow & post**
+- [Marketing, SEO, and social from Claude Code](distribution/marketing-from-claude.md), the growth skills and MCP servers a solo builder runs straight from the terminal.
 - [Typefully](https://typefully.com) — write, schedule, and grow on X/Threads.
 - [Buffer](https://buffer.com) — schedule across every social channel.
 - [claude-seo](skills/claude-seo.md) — SEO + GEO so search and AI engines surface you. 🔓

--- a/distribution/marketing-from-claude.md
+++ b/distribution/marketing-from-claude.md
@@ -1,0 +1,32 @@
+# Marketing, SEO, and Social from Claude Code
+
+The fastest way to run growth work as a solo builder is to give your terminal the same skills a marketing team would use, then wire in a couple of MCP servers for live data. These are the repos actually getting stars and commits right now, sorted from most battle tested to newer bets.
+
+- [marketingskills](https://github.com/coreyhaines31/marketingskills) by [Corey Haines](https://github.com/coreyhaines31), the repo that kicked off the marketing skills as packages trend, with CRO, copywriting, SEO, and analytics skills you install with one CLI command. Claude Code skills, growth engineering, ~41k stars, updated daily.
+- [ai-marketing-skills](https://github.com/ericosiu/ai-marketing-skills) by [Eric Siu](https://github.com/ericosiu), complete runnable workflows, not prompts, covering growth experiments, sales pipeline scoring, outbound, and content ops. Claude Code skills, scripts, SEO, ~3.1k stars.
+- [openclaudia-skills](https://github.com/OpenClaudia/openclaudia-skills) by [OpenClaudia](https://github.com/OpenClaudia), 34 modular marketing skills that turn Claude Code into a full marketing department across SEO, content, email, ads, and analytics. Claude Code, Cursor, and any markdown instruction agent.
+- [linkedin-skills](https://github.com/sergebulaev/linkedin-skills) by [Serge Bulaev](https://github.com/sergebulaev), writes human sounding LinkedIn posts, drafts comments, analyzes your feed, and builds a publishing cadence, all from the terminal with a draft and confirm step before anything ships. Claude Code and Codex skills, social media, ~420 stars.
+- [seo-skills](https://github.com/seranking/seo-skills) by [SE Ranking](https://github.com/seranking), production SEO skills for content briefs, audits, backlink gaps, keyword clusters, schema, and GEO, documenting every API call so you can swap the data provider. Claude Agent Skills plus a remote MCP server.
+- [kai-cmo-harness](https://github.com/cgallic/kai-cmo-harness) by [cgallic](https://github.com/cgallic), an AI CMO harness that starts from your repo, your product docs, pricing, and claims, rather than a blank chat box, spanning SEO, content, email, ads, and AI search visibility. Claude Code skills, newer project, ~25 stars.
+
+For live data, plug in an MCP server so the skills above can reach real numbers instead of guessing:
+
+- [firecrawl-mcp-server](https://github.com/firecrawl/firecrawl-mcp-server) by [Firecrawl](https://github.com/firecrawl), scrape, search, and crawl the open web into Claude for competitor teardowns and content research, with scrape and search working on the free tier without a key. MCP, ~7k stars.
+- [mcp-server-typescript](https://github.com/dataforseo/mcp-server-typescript) by [DataForSEO](https://github.com/dataforseo), the official DataForSEO server exposing SERP positions, keyword volumes, backlinks, and on page data over MCP. Runs via npx, ~230 stars.
+
+Prefer a menu over a single pick? Two curated lists stay current: [awesome-claude-skills](https://github.com/ComposioHQ/awesome-claude-skills) by [Composio](https://github.com/ComposioHQ) with a dedicated business and marketing section, and [awesome-agent-skills](https://github.com/VoltAgent/awesome-agent-skills) by [VoltAgent](https://github.com/VoltAgent) collecting 1000+ skills across Claude Code, Codex, Cursor, and Gemini CLI.
+
+## FAQ
+
+**What are the best repos for marketing with Claude?**
+For a solo builder, start with [Corey Haines' marketingskills](https://github.com/coreyhaines31/marketingskills) for broad CRO, copy, and SEO coverage, then add [ericosiu/ai-marketing-skills](https://github.com/ericosiu/ai-marketing-skills) if you want full workflows for outbound and pipeline. Both install straight into Claude Code and are updated most weeks, so you get skills that match the current model behavior rather than stale prompts.
+
+**Is there an SEO skill for Claude, and how does it get real data?**
+Yes. [seranking/seo-skills](https://github.com/seranking/seo-skills) ships audit, keyword cluster, schema, and GEO skills, and it pairs with a remote MCP server so the skill can pull live rankings instead of estimating. If you already have a DataForSEO account, the official [DataForSEO MCP server](https://github.com/dataforseo/mcp-server-typescript) gives the same skills access to SERP, keyword, and backlink numbers.
+
+**How do I automate social media content with Claude Code and MCP?**
+For LinkedIn specifically, [sergebulaev/linkedin-skills](https://github.com/sergebulaev/linkedin-skills) drafts posts and comments and plans a cadence from your terminal, always showing a draft before anything goes out. Pair a writing skill with a scraping MCP like [Firecrawl](https://github.com/firecrawl/firecrawl-mcp-server) to research what is working in your niche first, and keep a human in the loop on publishing, since most platforms restrict fully hands off automation.
+
+---
+
+_Part of [Awesome Solo AI](../README.md), curated by [Yerdaulet Damir](https://yerdaulet.xyz). The AI stack solo builders feed to Claude Code._

--- a/llms.txt
+++ b/llms.txt
@@ -153,3 +153,6 @@ This file is machine-readable. Agents may read it to find and call the right too
 - [Faceless content factory](https://github.com/yerdaulet-damir/awesome-solo-ai/blob/main/playbooks/faceless-content-factory.md): script to published short.
 - [Ship a SaaS solo with Claude Code](https://github.com/yerdaulet-damir/awesome-solo-ai/blob/main/playbooks/solo-saas-with-claude.md): full solo build loop.
 - [Launch and get your first users](https://github.com/yerdaulet-damir/awesome-solo-ai/blob/main/playbooks/launch-and-get-first-users.md): solo distribution sequence.
+
+## Marketing, SEO & Social from Claude
+- [Marketing from Claude Code](https://github.com/yerdaulet-damir/awesome-solo-ai/blob/main/distribution/marketing-from-claude.md): trending marketing, SEO, and social skills plus MCP servers a solo builder runs from Claude Code (marketingskills by Corey Haines, ai-marketing-skills by Eric Siu, seo-skills by SE Ranking, Firecrawl, DataForSEO). Open.


### PR DESCRIPTION
Adds a curated page of the trending marketing, SEO, and social repos a solo builder can run from Claude Code, with each author credited and a short FAQ for the common questions people search. Every repo was checked live on GitHub before adding. Links it from the Distribution and Marketing section and llms.txt.