### PR TITLE
Add trending Claude Code skills 2026 page

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,8 @@ A **Claude skill** is a reusable `.claude/skills` folder (markdown + scripts) th
 
 > ⚠️ **Security note:** skills are just markdown + shell. A 2026 Snyk study found ~13% of tested community skills had critical flaws, some exfiltrating credentials. Read the `SKILL.md` before installing anything outside Anthropic or an established maintainer.
 
+**More trending skills:** [browser control, reasoning, security, and research skills that gained traction in 2026](skills/trending-2026.md).
+
 **Discover more:** [awesome-claude-code](https://github.com/hesreallyhim/awesome-claude-code) (canonical, curated) · [awesome-claude-skills](https://github.com/travisvn/awesome-claude-skills) · [Claude Plugin Hub](https://www.claudepluginhub.com)
 
 ## Agent Memory & Knowledge

--- a/llms.txt
+++ b/llms.txt
@@ -159,3 +159,6 @@ This file is machine-readable. Agents may read it to find and call the right too
 
 ## AI Video Editing from Claude
 - [AI video editing repos](https://github.com/yerdaulet-damir/awesome-solo-ai/blob/main/guides/ai-video-editing-repos.md): how to edit or make video from Claude, MCP servers and pipelines (Kinocut, pireel, OpenMontage, MoneyPrinterTurbo, Remotion, HyperFrames). Open.
+
+## More Trending Skills (2026)
+- [Trending Claude Code skills 2026](https://github.com/yerdaulet-damir/awesome-solo-ai/blob/main/skills/trending-2026.md): newer community skills for browser control, reasoning, security, and research (chrome-cdp-skill, cc-thinking-skills, claude-code-owasp, context-engineering-kit, Bloom). Open.

--- a/skills/trending-2026.md
+++ b/skills/trending-2026.md
@@ -1,0 +1,26 @@
+# More Trending Claude Code Skills (2026)
+
+A fresh batch of community skills that have picked up traction in 2026, spanning browser control, reasoning, security, and research. Each one is credited to its author, and every repo was checked live before it went on this list.
+
+- [chrome-cdp-skill](https://github.com/pasky/chrome-cdp-skill) by [pasky](https://github.com/pasky), hooks Claude into your real, already open Chrome session so it can read tabs, logins, and live page state over CDP with zero dependencies. browser, automation, debugging.
+- [context-engineering-kit](https://github.com/NeoLabHQ/context-engineering-kit) by [NeoLabHQ](https://github.com/NeoLabHQ), a bundle of hand written skills for domain driven architecture and subagent driven development that push the agent toward higher quality output. context, architecture, workflow.
+- [cc-thinking-skills](https://github.com/tjboudreaux/cc-thinking-skills) by [tjboudreaux](https://github.com/tjboudreaux), 18 reasoning frameworks like First Principles, Bayesian updating, OODA, and Pre-Mortem, wired to a meta router that picks the right one for the problem. reasoning, planning.
+- [claude-code-owasp](https://github.com/agamm/claude-code-owasp) by [agamm](https://github.com/agamm), runs code review against OWASP Top 10:2025 and ASVS 5.0, with agentic AI checks and language specific quirks for 20 plus languages. security, code review.
+- [src-hunter-skill](https://github.com/MyuriKanao/src-hunter-skill) by [MyuriKanao](https://github.com/MyuriKanao), a bug bounty and vuln hunting workhorse with attack playbooks, a large structured payload set, and WAF and EDR bypass references. security, bug bounty.
+- [Bloom](https://github.com/Li-Evan/Bloom) by [Li-Evan](https://github.com/Li-Evan), turns Claude into a Socratic private tutor that adapts to how you actually learn, based on Bloom's 2 sigma research, and ships with a self hostable web app. learning, tutoring.
+- [ai-research-skills](https://github.com/WenyuChiou/ai-research-skills) by [WenyuChiou](https://github.com/WenyuChiou), a 15 skill catalog covering the research pipeline from literature review and research design to project memory and manuscript writing. research, writing.
+
+## FAQ
+
+**What are the best new Claude Code skills to try in 2026?**
+Beyond the usual staples, the fresh standouts are chrome-cdp-skill for driving your real browser, cc-thinking-skills for structured reasoning, and claude-code-owasp for security review. Each one solves a concrete workflow gap rather than repackaging what Claude already does. Pick by the job in front of you, not by star count.
+
+**How do I find trending Claude Code skills on GitHub?**
+Watch the curated lists like ComposioHQ/awesome-claude-skills and hesreallyhim/awesome-claude-code, then cross check candidates against their live GitHub stars and last commit date. A skill that has not been pushed to in a few months is often drifting out of date, so recency matters as much as popularity. Directories like skills.sh also let you sort by install count.
+
+**Are community Claude Code skills safe to install?**
+Skills can run arbitrary code in your environment, so treat them like any dependency and only install from authors you can vet. Read the SKILL.md and any bundled scripts before running, and prefer repos with real activity and a visible author over anonymous one off drops. When in doubt, clone it and inspect the files first.
+
+---
+
+_Part of [Awesome Solo AI](../README.md), curated by [Yerdaulet Damir](https://yerdaulet.xyz). The AI stack solo builders feed to Claude Code._


### PR DESCRIPTION
Adds a page of newer community Claude Code skills that gained traction in 2026, across browser control, reasoning, security, and research, with each author credited and a short FAQ, plus a note on vetting skills before installing. Every repo was checked live on GitHub. Linked from the skills section and llms.txt.