### PR TITLE
Add trending MCP servers 2026 page

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,8 @@ Model Context Protocol servers let your agent *do things*, not just chat. These 
 - [Browserbase MCP](mcp/browserbase.md) — cloud browser for clicks, form fills, and screenshots when scraping isn't enough. 🧩
 - [Sequential Thinking MCP](mcp/sequential-thinking.md) — externalises step-by-step reasoning; #1 by usage on Smithery. 🔓
 
+**More MCP servers:** [docs, search, data, email, and deploy servers worth wiring up in 2026](mcp/trending-2026.md).
+
 **Registries to discover more:** [Official MCP Registry](https://github.com/modelcontextprotocol/registry) · [Smithery](https://smithery.ai) · [mcp.so](https://mcp.so) · [PulseMCP](https://www.pulsemcp.com) · [Glama](https://glama.ai/mcp/servers)
 
 ## Claude Skills & Plugins

--- a/llms.txt
+++ b/llms.txt
@@ -162,3 +162,6 @@ This file is machine-readable. Agents may read it to find and call the right too
 
 ## More Trending Skills (2026)
 - [Trending Claude Code skills 2026](https://github.com/yerdaulet-damir/awesome-solo-ai/blob/main/skills/trending-2026.md): newer community skills for browser control, reasoning, security, and research (chrome-cdp-skill, cc-thinking-skills, claude-code-owasp, context-engineering-kit, Bloom). Open.
+
+## More MCP Servers (2026)
+- [Trending MCP servers 2026](https://github.com/yerdaulet-damir/awesome-solo-ai/blob/main/mcp/trending-2026.md): docs, search, data, email, and deploy servers for solo builders (Context7, Claude Context, Tavily, Apify, Neon, Resend, Sentry, Cloudflare). Open.

--- a/mcp/trending-2026.md
+++ b/mcp/trending-2026.md
@@ -1,0 +1,27 @@
+# More MCP Servers Worth Wiring Up (2026)
+
+A few servers that keep showing up in solo builder stacks, covering docs, search, data, email, and deploy. Each is credited to its maker, and every repo was checked live before it went on this list.
+
+- [Context7 MCP](https://github.com/upstash/context7) by [Upstash](https://github.com/upstash), pulls version specific library docs straight into the prompt so the model stops guessing at APIs. docs, coding, free tier.
+- [Claude Context MCP](https://github.com/zilliztech/claude-context) by [Zilliz](https://github.com/zilliztech), indexes your whole codebase into a vector store so the agent finds the right files without blowing up the context window. code search, memory.
+- [Tavily MCP](https://github.com/tavily-ai/tavily-mcp) by [Tavily](https://github.com/tavily-ai), real time web search plus extract, map, and crawl, with a hosted endpoint if you do not want to run it locally. search, research.
+- [Apify MCP](https://github.com/apify/actors-mcp-server) by [Apify](https://github.com/apify), lets an agent run thousands of ready made scrapers to pull data from social, maps, and e commerce sites. scraping, data.
+- [Neon MCP](https://github.com/neondatabase/mcp-server-neon) by [Neon](https://github.com/neondatabase), spin up serverless Postgres, run queries, and do migrations in plain language. database, backend.
+- [Resend MCP](https://github.com/resend/mcp-send-email) by [Resend](https://github.com/resend), send transactional email and manage contacts, broadcasts, and domains from the agent. email, comms.
+- [Sentry MCP](https://github.com/getsentry/sentry-mcp) by [Sentry](https://github.com/getsentry), hands the agent your production errors, stack traces, and issues so it debugs from real data. observability, debugging.
+- [Cloudflare MCP](https://github.com/cloudflare/mcp-server-cloudflare) by [Cloudflare](https://github.com/cloudflare), a bundle of servers for Workers, DNS, and observability so you can deploy and inspect edge apps. deploy, infra.
+
+## FAQ
+
+**What are the best MCP servers for solo builders in 2026?**
+It depends on the job, but a lean stack covers search, data, and shipping. Tavily or Context7 for pulling in fresh information, Neon for a Postgres backend, Resend for email, and Cloudflare for deploy will handle most of what a one person product needs. Add Sentry once you have real users and want the agent to help debug production.
+
+**Which MCP server gives an AI coding agent up to date documentation?**
+Context7 by Upstash is the common pick. It fetches version specific docs and code examples for hundreds of frameworks and drops them into the prompt, which cuts down on the model inventing APIs that do not exist. It works with Claude Code, Cursor, and most other MCP clients, and the free tier is enough to start.
+
+**Is there an MCP server for semantic code search across a large codebase?**
+Yes, Claude Context by Zilliz indexes your repo into a vector database and does hybrid keyword plus vector retrieval, so the agent gets only the relevant files instead of the entire tree. It needs an embedding provider key and a Zilliz Cloud vector store, and it plugs into Claude Code, Cursor, and VS Code. This is useful once a project grows past what fits comfortably in context.
+
+---
+
+_Part of [Awesome Solo AI](../README.md), curated by [Yerdaulet Damir](https://yerdaulet.xyz). The AI stack solo builders feed to Claude Code._


### PR DESCRIPTION
Adds a page of MCP servers that keep showing up in solo builder stacks in 2026, across docs, search, data, email, and deploy, with each maker credited and a short FAQ. Every repo was checked live on GitHub. Linked from the MCP Servers section and llms.txt.