### PR TITLE
Add self-hosted analytics page

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,7 @@ The plumbing a solo builder needs to ship and run an AI product — picked for t
 - [Supabase](https://supabase.com) — Postgres + auth + storage with `pgvector` built in, so it doubles as the vector store for your RAG. 🔌 🔓
 - [Vercel](https://vercel.com) — deploy in one push, plus the [AI SDK](https://sdk.vercel.ai) and [v0](https://v0.dev) for building AI UIs. 🔌
 - [PostHog](https://posthog.com) — product analytics, session replay, and LLM analytics to track AI feature cost and quality. 🔌 🔓
+- [Self-hosted analytics for solo builders](guides/self-hosted-analytics.md), open-source web, product, and LLM observability you can own (Umami, Plausible, Langfuse, Helicone) plus analytics MCP servers.
 - [Convex](https://convex.dev) — reactive backend with first-class AI agent and workflow support. 🔌
 - [Clerk](https://clerk.com) — drop-in auth so you skip building login. 🔌
 - [tgx](https://github.com/yerdaulet-damir/tgx) — TypeScript framework for building Telegram bots fast on grammY; state, Stars payments and menus built in, and designed to be built by AI agents (ships an MCP server). 🔓

--- a/guides/self-hosted-analytics.md
+++ b/guides/self-hosted-analytics.md
@@ -1,0 +1,40 @@
+# Analytics for Solo Builders (Self-Hosted and Open-Source)
+
+Analytics you can run yourself, own the data, and point an agent at. Web, product, and LLM observability, all open source or self hostable, all verified live in July 2026.
+
+## Web and product analytics
+
+- [Umami](https://github.com/umami-software/umami) by [Umami Software](https://github.com/umami-software), single page, cookieless web analytics that runs in one Postgres container. open source, self hosted, web analytics, api.
+- [Plausible](https://github.com/plausible/analytics) by [Plausible](https://github.com/plausible), a script under 1KB that reports pageviews, visitors, and referrers with no cookies. open source, self hosted, web analytics, api.
+- [Rybbit](https://github.com/rybbit-io/rybbit) by [Rybbit](https://github.com/rybbit-io), a newer GA alternative that adds session replay, funnels, and web vitals in one dashboard. open source, self hosted, product analytics, session replay.
+- [GoatCounter](https://github.com/arp242/goatcounter) by [Martin Tournoij](https://github.com/arp242), a tiny Go binary for privacy friendly pageview counting with no personal data stored. open source, self hosted, web analytics, lightweight.
+- [Matomo](https://github.com/matomo-org/matomo) by [Matomo](https://github.com/matomo-org), the full Google Analytics replacement with goals, heatmaps, and a complete reporting API. open source, self hosted, web analytics, api.
+- [Medama](https://github.com/medama-io/medama) by [Medama](https://github.com/medama-io), a single binary privacy first analytics server for people who want the smallest possible footprint. open source, self hosted, web analytics, lightweight.
+
+## LLM and AI observability
+
+- [Langfuse](https://github.com/langfuse/langfuse) by [Langfuse](https://github.com/langfuse), traces every LLM call, run, and eval, with prompt management and datasets, self hosted in about five minutes. open source, self hosted, llm observability, evals, mcp.
+- [Helicone](https://github.com/Helicone/helicone) by [Helicone](https://github.com/Helicone), a one line proxy that logs cost, latency, and quality across 100+ models and ships its own MCP server. open source, self hosted, llm observability, proxy, mcp.
+- [OpenLLMetry](https://github.com/traceloop/openllmetry) by [Traceloop](https://github.com/traceloop), OpenTelemetry native instrumentation so your LLM traces land in whatever backend you already run. open source, opentelemetry, llm observability.
+- [Arize Phoenix](https://github.com/Arize-ai/phoenix) by [Arize AI](https://github.com/Arize-ai), local first tracing and evaluation for RAG and agent apps, runs in a notebook or a container. open source, self hosted, llm observability, evals.
+
+## Analytics MCP servers
+
+- [PostHog MCP](https://github.com/PostHog/mcp) by [PostHog](https://github.com/PostHog), the official server that lets an agent query insights, funnels, and feature flags from your PostHog project. mcp, product analytics, official.
+- [Grafana MCP](https://github.com/grafana/mcp-grafana) by [Grafana](https://github.com/grafana), lets an agent pull dashboards, query Prometheus and Loki, and read incidents straight from Grafana. mcp, observability, official.
+- [Sentry MCP](https://github.com/getsentry/sentry-mcp) by [Sentry](https://github.com/getsentry), gives an agent access to issues, traces, and error context from your Sentry org. mcp, error monitoring, official.
+
+## FAQ
+
+**What are the best open source, self-hosted web analytics tools?**
+Umami and Plausible are the two most reached for picks, both cookieless and both replacing Google Analytics with a sub 1KB script and a clean single page dashboard. If you want more than pageviews, Rybbit adds session replay and funnels, while Matomo covers the heavier enterprise end with a full reporting API. All four run in Docker and keep the event data on your own server.
+
+**How do I add LLM observability to an indie AI product?**
+Start with Langfuse or Helicone, since both self host in minutes and need almost no code. Helicone works as a one line proxy that logs every request, so you get cost and latency tracking without touching your app logic, while Langfuse uses SDK decorators and gives you traces, evals, and prompt versioning. If you already run OpenTelemetry, OpenLLMetry sends the same LLM traces into your existing backend instead of a new dashboard.
+
+**What is an analytics MCP server and why would I want one?**
+An analytics MCP server exposes your metrics to an AI agent over the Model Context Protocol, so Claude or Cursor can query the numbers directly instead of you clicking through a dashboard. PostHog, Grafana, and Sentry all ship official ones, and Langfuse and Helicone bundle MCP servers for their LLM traces. In practice you ask a question in plain language, the agent runs the query, and you debug an error or read a funnel without leaving your editor.
+
+---
+
+_Part of [Awesome Solo AI](../README.md), curated by [Yerdaulet Damir](https://yerdaulet.xyz). The AI stack solo builders feed to Claude Code._

--- a/llms.txt
+++ b/llms.txt
@@ -171,3 +171,6 @@ This file is machine-readable. Agents may read it to find and call the right too
 
 ## SEO & GEO Tools
 - [SEO and GEO tools](https://github.com/yerdaulet-damir/awesome-solo-ai/blob/main/distribution/seo-geo-tools.md): skills and MCP servers to rank in Google and get cited by AI engines (SE Ranking seo-skills, GEO Optimizer, DataForSEO MCP, AutoGEO, llms.txt generator). Open.
+
+## Self-Hosted Analytics
+- [Analytics for solo builders](https://github.com/yerdaulet-damir/awesome-solo-ai/blob/main/guides/self-hosted-analytics.md): open-source web, product, and LLM observability plus analytics MCP servers (Umami, Plausible, Rybbit, Langfuse, Helicone, PostHog MCP, Grafana MCP). Open.


### PR DESCRIPTION
Adds a curated page of open-source and self-hostable analytics for solo builders, covering web, product, and LLM observability plus analytics MCP servers, with each project credited and a short FAQ. Every repo was checked live on GitHub before adding. Linked from the analytics section and llms.txt.