### PR TITLE
Add frameworks for building page

### DIFF
--- a/tools/frameworks-for-building.md
+++ b/tools/frameworks-for-building.md
@@ -1,0 +1,41 @@
+# Frameworks for Building Fast
+
+Frameworks a solo builder actually reaches for in 2026, each one proven with AI coding agents and shipping real products. Checked live in July 2026.
+
+## Web
+
+- [Next.js](https://github.com/vercel/next.js) by [Vercel](https://vercel.com), the default when you want one framework that does SSR, API routes, and a marketing site plus an app dashboard in the same repo. react, ssr, fullstack.
+- [Astro](https://github.com/withastro/astro) by [Astro](https://astro.build), reach for it when the site is mostly content, blog, docs, or landing pages, and you want near zero JavaScript shipped by default. content, static, islands.
+- [SvelteKit](https://github.com/sveltejs/kit) by [Svelte](https://svelte.dev), pick it when you want less boilerplate than React and a compiler that ships small bundles for a fast app. svelte, compiler, fullstack.
+- [TanStack Start](https://github.com/TanStack/router) by [TanStack](https://tanstack.com), use it when end to end type safety on routes, params, and loaders matters more than ecosystem size. react, typesafe, ssr.
+- [React Router](https://github.com/remix-run/react-router) by [Remix](https://reactrouter.com), the successor to Remix, use it as a full framework or a plain router when you want to own your own architecture. react, router, framework.
+
+## Full-stack
+
+- [Convex](https://github.com/get-convex/convex-backend) by [Convex](https://convex.dev), reach for it when you want a reactive database, server functions, and realtime queries without standing up your own backend. reactive, backend, realtime.
+- [RedwoodSDK](https://github.com/redwoodjs/sdk) by [RedwoodJS](https://redwoodjs.com), pick it when you want server first React with server functions and a type safe router running on Cloudflare with minimal setup. react, cloudflare, server first.
+
+## Mobile and desktop
+
+- [Expo](https://github.com/expo/expo) by [Expo](https://expo.dev), the fastest path to a real iOS and Android app from one React Native codebase, with over the air updates and no Xcode wrestling to start. react native, ios, android.
+- [Tauri](https://github.com/tauri-apps/tauri) by [Tauri](https://tauri.app), use it when you want a small, fast desktop app from web tech with a Rust core instead of shipping a whole Chromium like Electron. desktop, rust, lightweight.
+
+## AI SDKs
+
+- [Vercel AI SDK](https://github.com/vercel/ai) by [Vercel](https://ai-sdk.dev), reach for it when you want to stream model responses and call tools in a TypeScript app with one API across providers. typescript, streaming, agents.
+- [Mastra](https://github.com/mastra-ai/mastra) by [Mastra](https://mastra.ai), pick it when the AI part grows past a single call into agents, workflows, and evals that need structure. typescript, agents, workflows.
+
+## FAQ
+
+**What is the best framework to build a SaaS solo in 2026?**
+For a full SaaS with auth, billing, and a dashboard, Next.js paired with Convex is the shortest path, Next.js handles the UI and marketing pages while Convex gives you a reactive database and server functions with no backend to run. If you want everything in one framework and end to end types, TanStack Start is the strong alternative. Both pair cleanly with an AI coding agent because the file conventions are predictable, which means the agent guesses right more often.
+
+**Next.js or Astro for a marketing site?**
+Use Astro if the site is content first, a landing page, a blog, or docs, because it ships almost no JavaScript by default and stays fast on cheap hosting. Reach for Next.js when the marketing site and the actual product app live in the same codebase and you do not want to run two frameworks. A common solo setup is Astro for the public site and Next.js or TanStack Start for the app behind login.
+
+**How do I build a mobile app as a solo developer?**
+Use Expo, it wraps React Native so one codebase ships to both iOS and Android, and over the air updates let you push fixes without a full app store review each time. If you already know React, most of what you know carries over, and an AI agent can scaffold screens and navigation quickly. When you need a desktop version too, Tauri lets you reuse your web UI in a small native shell instead of maintaining a separate app.
+
+---
+
+_Part of [Awesome Solo AI](../README.md), curated by [Yerdaulet Damir](https://yerdaulet.xyz). The AI stack solo builders feed to Claude Code._


### PR DESCRIPTION
Adds a curated page of frameworks a solo builder ships with in 2026, across web, full-stack, mobile and desktop, and AI SDKs, with each project credited and a short FAQ. Every repo was checked live on GitHub before adding. Left open for review.