### PR TITLE
Add where to launch page

### DIFF
--- a/distribution/where-to-launch.md
+++ b/distribution/where-to-launch.md
@@ -1,0 +1,44 @@
+# Where to Launch an Open-Source or AI Product
+
+These are the launch boards, directories, and communities that actually send traffic or pass link value as of July 2026. Pick three or four for launch week and add one or two per quarter. Spraying dozens of low authority directories dilutes your link profile and wastes your time. Domain ratings below are approximate and move over time.
+
+- [Product Hunt](https://www.producthunt.com), the default launch board for tech and AI products, free to submit, links are nofollow but referral traffic and the DR 90+ profile page make it worth a coordinated launch day.
+- [Show HN](https://news.ycombinator.com/showhn.html), Hacker News for things people can run or try, free, accepts working projects and open source repos but not blog posts or signup pages, nofollow, front page drives a real traffic spike.
+- [Peerlist Launchpad](https://peerlist.io/launchpad), a maker community with weekly launches, free with an account, strong DR ~76 and an engaged audience, treat the link as nofollow.
+- [Fazier](https://fazier.com), a daily product board, free, gives a dofollow link from a DR ~82 domain, one of the best free authority links available.
+- [SaaSHub](https://www.saashub.com), an evergreen SaaS and alternatives directory running since 2014, free listing with paid featuring, dofollow link at DR ~74, submit any time since it is not time sensitive.
+- [BetaList](https://betalist.com), the pre launch directory for collecting beta signups, free queue or paid skip, dofollow at DR ~78, submit three to four weeks before shipping, less useful after launch.
+- [Uneed](https://www.uneed.best), a curated maker launch board with a rolling leaderboard, free queue plus paid tiers, DR ~62, dofollow is often reserved for paid placement.
+- [DevHunt](https://devhunt.org), a community board specifically for developer tools, free, dofollow, a good fit for open source dev tooling and CLIs.
+- [MicroLaunch](https://microlaunch.net), a launch board for indie and micro startups, free with a paid pro tier, dofollow, smaller but active audience.
+- [Startup Fame](https://startupfa.me), a startup and side project directory, free if you embed their badge or paid from $19 a month, dofollow from a DR ~80 domain.
+- [Tiny Launch](https://www.tinylaunch.com), a daily launch board, free plus paid premium, dofollow granted when you embed a dofollow badge on your site, top three daily get extra placement.
+- [AlternativeTo](https://alternativeto.net), a large crowd sourced app directory, free to add an app, links are nofollow but the DR ~89 pages rank well for alternative to X searches.
+- [Indie Hackers](https://www.indiehackers.com), a founder community where you post your product and build in public, free, nofollow, drives feedback and early users more than SEO.
+- [ToolFolio](https://toolfolio.com), an AI and software discovery directory, free listing with paid boosted placement, dofollow reported, mid authority.
+- [daily.dev](https://daily.dev), a developer content feed with Squads, free, no formal product listing so use it to share a launch post to developers, not for a backlink.
+
+## Submission checklist
+
+1. Ship a working demo or public repo with a clear README, most boards reject dead links and signup walls.
+2. Prepare one tagline, a 60 word description, a square logo, and two or three screenshots or a short video.
+3. Submit to BetaList first if you are pre launch, its queue is the longest.
+4. Cluster the launch day boards, Product Hunt, Fazier, Uneed, Peerlist, into a 24 to 48 hour window.
+5. Post Show HN and an Indie Hackers thread on the same day and reply to every comment.
+6. Add the evergreen listings, SaaSHub, AlternativeTo, DevHunt, any time after, they are not time sensitive.
+7. Embed any required badge before submitting to Startup Fame or Tiny Launch so the dofollow link activates.
+
+## FAQ
+
+**Where do I launch an open-source project?**
+Start with Show HN and DevHunt, both accept working code and open source repos and put you in front of developers. Add GitHub topics and a strong README, then post to relevant subreddits like r/opensource and r/SideProject. Product Hunt works too if the project has a usable hosted demo, not just a repo.
+
+**Which directories give dofollow backlinks?**
+Fazier, SaaSHub, BetaList, DevHunt, MicroLaunch, and Startup Fame give dofollow links, Fazier at DR ~82 is the strongest free one. Tiny Launch and Startup Fame require you to embed their badge for the dofollow link to count. Product Hunt, Peerlist, AlternativeTo, and Hacker News are nofollow, you do them for traffic and reach, not link juice.
+
+**Is Product Hunt still worth it in 2026?**
+Yes for the referral traffic and the profile page, no if your only goal is a backlink since the links are nofollow. A coordinated launch still brings a same day spike in visitors and signups and gets you noticed by newsletters and other makers. Treat it as a traffic and awareness event, and get your real SEO value from the dofollow directories.
+
+---
+
+_Part of [Awesome Solo AI](../README.md), curated by [Yerdaulet Damir](https://yerdaulet.xyz). The AI stack solo builders feed to Claude Code._


### PR DESCRIPTION
Adds a curated page of launch boards, directories, and communities where a solo builder submits a product to get traffic and backlinks, with honest notes on cost and dofollow vs nofollow, a submission checklist, and a short FAQ. Every URL was checked live before adding. Left open for review.