### PR TITLE
Add AI tool and MCP directories page

### DIFF
--- a/distribution/ai-mcp-directories.md
+++ b/distribution/ai-mcp-directories.md
@@ -1,0 +1,41 @@
+# AI Tool and MCP Directories
+
+Where a solo builder actually lists an AI tool or MCP server to get found and earn backlinks. Every entry below resolves live as of July 2026.
+
+## AI tool directories
+
+- [There's An AI For That](https://theresanaiforthat.com/get-featured/), the largest AI tool index, submit through Get Featured for a $347 one off that is refunded if your tool is rejected.
+- [Futurepedia](https://www.futurepedia.io/submit-tool), a large general AI directory with a free listing tier and paid featured placement.
+- [aitools.fyi](https://aitools.fyi), a categorized AI directory where the free submit form routes through boostmytool.com, with paid featured slots on top.
+- [Toolify](https://www.toolify.ai), a ~30,000 tool directory with a free submit page plus paid advertising and guest posts.
+- [AI Scout](https://aiscout.net/submit-listing/), a UK AI tools directory of 1,500+ entries, account required to submit and at least one review reports a paid featured tier, so check the current price on the page.
+- [Insidr.ai](https://www.insidr.ai), a smaller curated directory with a free submit a tool page that monetizes through courses rather than listings.
+
+## MCP registries
+
+- [Smithery](https://smithery.ai/submit), the main agent framework MCP hub, list for free by pushing a smithery.yaml to your repo or running the @smithery/cli.
+- [PulseMCP](https://www.pulsemcp.com), a curated MCP hub that syncs from the official registry, free with no paid placement.
+- [Glama](https://glama.ai/mcp/servers), a 60,000 plus server index with a free Add Server button and per language and capability filters.
+- [mcp.so](https://mcp.so), a community MCP marketplace of 20,000 plus servers, submit for free by opening a GitHub issue from the Submit link.
+- [Official MCP Registry](https://github.com/modelcontextprotocol/registry), the canonical registry other directories pull from, publish for free with its CLI using GitHub auth or DNS verification.
+
+## Awesome-list aggregators
+
+- [awesome.re](https://awesome.re), the root of Sindre Sorhus's Awesome index, get in for free by opening a pull request that meets the awesome manifesto bar, one of the highest authority backlinks available.
+- [Track Awesome List](https://www.trackawesomelist.com), a tracker of 500 plus awesome lists that picks yours up automatically once it is an established awesome repo, no submit form.
+- [LibHunt](https://www.libhunt.com), a 540,000 project discovery engine, add yours for free at /repo/submit and it also surfaces projects by social mentions.
+
+## FAQ
+
+**Where do I list my AI tool?**
+Start with There's An AI For That for reach, budgeting the $347 one off, then cover the free tiers at Futurepedia, Toolify, aitools.fyi, and Insidr.ai. The paid TAAFT slot drives the most real discovery traffic, while the free directories mostly earn you backlinks and long tail search visibility. Prepare one metadata set, name, one sentence description, category, pricing, and a logo, and reuse it across every form.
+
+**Where do I submit an MCP server?**
+List the same server across all four registries that matter, since each has a different audience. Publish to the Official MCP Registry with its CLI first because other directories pull from it, then add Smithery for the agent framework crowd, Glama and mcp.so for browsers, and let PulseMCP pick it up from the official feed. All five are free, and the metadata they want is identical, server name, capability sentence, tool count, transport type, repo URL, and an icon.
+
+**How do I get my repo into an awesome list?**
+Find the specific awesome list for your niche, for example awesome-mcp-servers or an awesome-ai list, and open a pull request that adds your entry in the existing format with a real one line description. Getting into the root awesome.re index is harder because it enforces the awesome manifesto, so your list needs genuine curation and a proper readme. Once you are in an active list, trackers like Track Awesome List and aggregators like LibHunt surface you automatically without any extra submission.
+
+---
+
+_Part of [Awesome Solo AI](../README.md), curated by [Yerdaulet Damir](https://yerdaulet.xyz). The AI stack solo builders feed to Claude Code._


### PR DESCRIPTION
Adds a curated page of AI tool directories, MCP registries, and awesome-list aggregators where a solo builder lists a tool or server to get found, with honest notes on cost and traffic quality and a short FAQ. Every URL was checked live before adding. Left open for review.