### PR TITLE
Add podcasts and learning page

### DIFF
--- a/guides/podcasts-and-learning.md
+++ b/guides/podcasts-and-learning.md
@@ -1,0 +1,42 @@
+# Podcasts, YouTube, and Newsletters for Solo AI Builders
+
+The podcasts, YouTube channels, and newsletters solo builders actually use to build and grow AI products, each checked live as of July 2026.
+
+## Podcasts
+
+- [Indie Hackers Podcast](https://www.indiehackers.com/podcast) by [Courtland Allen](https://www.indiehackers.com), where founders walk through their real revenue and the exact channel that landed their first paying customers.
+- [Lenny's Podcast](https://www.lennysnewsletter.com/podcast) by [Lenny Rachitsky](https://www.lennysnewsletter.com), where the operators behind well known products break down the product, growth, and pricing calls they actually made.
+- [My First Million](https://www.mfmpod.com/) by [Shaan Puri](https://shaanpuri.com) and Sam Parr, a running feed of business ideas and market gaps that helps you spot what a solo builder could ship next.
+- [The Startup Ideas Podcast](https://open.spotify.com/show/6aB0v6amo3a8hgTCjlTlvh) by [Greg Isenberg](https://www.youtube.com/@GregIsenberg), twice weekly teardowns of specific AI product ideas, often built live with tools you can copy.
+- [Latent Space](https://www.latent.space/podcast) by [swyx](https://www.swyx.io) and Alessio Fanelli, where AI engineers explain how they build agents, RAG, and eval pipelines that reach production.
+- [How I Write](https://writeofpassage.com/how-i-write) by [David Perell](https://perell.com), where working writers show how they structure essays and hooks, which maps directly onto landing pages and launch posts.
+- [a16z Podcast](https://a16z.com/podcasts/) by [Andreessen Horowitz](https://a16z.com), where investors and founders lay out where AI, infrastructure, and markets are heading before it is obvious.
+- [Y Combinator](https://www.youtube.com/@ycombinator/podcasts) by [YC partners](https://www.ycombinator.com), including the Lightcone show, with honest talk on which AI startups are working right now and the mistakes to skip.
+
+## YouTube
+
+- [IndyDevDan](https://www.youtube.com/@indydevdan) by [Dan](https://www.youtube.com/@indydevdan), production workflows for agentic coding with Claude Code and MCP, aimed at engineers shipping real software.
+- [Cole Medin](https://www.youtube.com/@ColeMedin) by [Cole Medin](https://www.youtube.com/@ColeMedin), end to end AI agent builds in n8n, LangGraph, and the OpenAI Agents SDK with cost and reliability tradeoffs spelled out.
+- [Fireship](https://www.youtube.com/@Fireship) by [Jeff Delaney](https://www.youtube.com/@Fireship), fast, dense explainers on new frameworks and tools so you can decide what to learn without sitting through a long tutorial.
+- [Marc Lou](https://www.youtube.com/@marc-lou) by [Marc Lou](https://www.youtube.com/@marc-lou), how one solo founder markets and ships small SaaS and boilerplates, with the actual numbers behind each launch.
+- [Matthew Berman](https://www.youtube.com/@matthew_berman) by [Matthew Berman](https://www.youtube.com/@matthew_berman), near daily hands on tests of new AI models and tools, a quick way to keep up without reading every release.
+
+## Newsletters
+
+- [Ben's Bites](https://bensbites.co/) by [Ben Tossell](https://bensbites.co/), a five minute daily digest of AI launches and news filtered for people who are actually building products.
+- [Lenny's Newsletter](https://www.lennysnewsletter.com) by [Lenny Rachitsky](https://www.lennysnewsletter.com), researched deep dives on product, growth, and pricing that you can apply the same week.
+
+## FAQ
+
+**What are the best podcasts for indie hackers in 2026?**
+Indie Hackers and My First Million cover the business side, real revenue, distribution, and picking what to build. For building with AI on top of that, The Startup Ideas Podcast and Latent Space go deeper on what to make and how to ship it. Most solo builders rotate through all four rather than picking one.
+
+**Where do solo founders learn to build with AI?**
+YouTube is where the hands on work lives, IndyDevDan for agentic coding, Cole Medin for full agent builds, and Matthew Berman to track new models. Latent Space fills in the engineering behind agents and evals, and Ben's Bites keeps you current on launches in about five minutes a day.
+
+**What is the best AI engineering podcast?**
+Latent Space is the closest thing to a canonical AI engineering show, hosted by swyx and Alessio Fanelli, who interview the people building frontier models, agents, and infrastructure. Episodes get into concrete details like eval design and agent architecture instead of headlines. Pair it with the a16z Podcast when you also want the market and funding context.
+
+---
+
+_Part of [Awesome Solo AI](../README.md), curated by [Yerdaulet Damir](https://yerdaulet.xyz). The AI stack solo builders feed to Claude Code._


### PR DESCRIPTION
Adds a curated page of podcasts, YouTube channels, and newsletters a solo AI builder follows to build and grow, with each host credited and a short FAQ. Every URL was checked live before adding. Left open for review.