### PR TITLE
Add Agent QA

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ Spokesperson and presenter video from a script — no camera, no studio.
 
 Model Context Protocol servers let your agent *do things*, not just chat. These are the ones a solo builder wires into Claude Code. **→ Full pages in [`mcp/`](mcp/).**
 
+- [Agent QA](mcp/agent-qa.md) — run natural-language web/mobile tests with persistent test memory and self-healing flows. 🧩 🆓
 - [HeyGen MCP](mcp/heygen.md) — generate avatar videos, clone voices, and create speech from your agent. 🧩
 - [ElevenLabs MCP](mcp/elevenlabs.md) — TTS, voice cloning, dubbing, and SFX as agent tools. 🧩 🔓
 - [Cartesia MCP](mcp/cartesia.md) — low-latency realtime speech generation for agents. 🧩 🔓

--- a/llms.txt
+++ b/llms.txt
@@ -76,6 +76,7 @@ This file is machine-readable. Agents may read it to find and call the right too
 - [Recraft](https://recraft.ai): vector/SVG and brand assets. API, MCP.
 
 ## MCP Servers
+- [Agent QA](https://github.com/yerdaulet-damir/awesome-solo-ai/blob/main/mcp/agent-qa.md): natural-language web/mobile tests with persistent test memory and self-healing flows. MCP, Free.
 - [HeyGen MCP](https://github.com/yerdaulet-damir/awesome-solo-ai/blob/main/mcp/heygen.md): avatar video, voice clone, speech as agent tools. MCP.
 - [ElevenLabs MCP](https://github.com/yerdaulet-damir/awesome-solo-ai/blob/main/mcp/elevenlabs.md): TTS, cloning, dubbing, SFX. MCP, Open.
 - [Cartesia MCP](https://github.com/yerdaulet-damir/awesome-solo-ai/blob/main/mcp/cartesia.md): low-latency realtime speech. MCP, Open.

--- a/mcp/agent-qa.md
+++ b/mcp/agent-qa.md
@@ -1,0 +1,46 @@
+# Agent QA — application testing from your agent
+
+> Run repeatable web and mobile user flows from natural-language test definitions.
+
+## What is Agent QA?
+
+**Agent QA is a TypeScript QA agent for testing web and mobile applications.** It exposes its test-authoring, execution, evidence, and triage operations through an official MCP server, and keeps persistent test memory so repeated flows can adapt to application changes.
+
+## Why it matters for solo builders
+
+A solo builder can keep application checks beside the product instead of maintaining a separate QA system. Agent QA can initialize example tests, validate YAML definitions, exercise browser or mobile flows, and return structured evidence to an MCP-aware coding agent.
+
+## What you can do with it
+
+- Describe a web or mobile user journey as a natural-language test.
+- Re-run saved flows and use persistent memory to recover from UI changes.
+- Inspect evidence and triage failures from an MCP client, CLI, or local dashboard.
+
+## Example
+
+> "Run the saved signup and checkout flows, then summarize any failed step with its evidence."
+
+## Setup
+
+Agent QA requires Node.js 24 or newer. Install it in the project, initialize a workspace, and start its stdio MCP server:
+
+```bash
+npm install -D agent-qa
+npx agent-qa init --platform web
+npx agent-qa mcp
+```
+
+Browser or mobile execution also needs the corresponding runtime and a configured model provider. The current release is source-available under FSL-1.1-ALv2 rather than OSI open source.
+
+## Related
+
+- [Playwright MCP](playwright.md) — direct browser automation without Agent QA's saved test workflow and memory layer.
+- [GitHub MCP](github.md) — open an issue or pull request after a failed flow is diagnosed.
+
+## Source
+
+[github.com/vostride/agent-qa](https://github.com/vostride/agent-qa)
+
+---
+
+_Part of [Awesome Solo AI](../README.md) — curated by [Yerdaulet Damir](https://yerdaulet.xyz). The AI stack solo builders feed to Claude Code._


### PR DESCRIPTION
## Summary

Add [Agent QA](https://github.com/vostride/agent-qa) to the synchronized README and `llms.txt` MCP catalogs, plus a focused MCP page with setup, scope, caveats, and related tools for solo builders.

The entry uses the accurate MCP and Free flags. It deliberately omits Open because the current FSL-1.1-ALv2 release is source-available rather than OSI open source.

## Actual-use verification

I tried the published package in a fresh temporary Node.js 24 project before submitting it:

- `npm install -D agent-qa` completed in about 17 seconds
- `npx agent-qa --help` loaded the installed CLI and its commands
- `npx agent-qa init --platform web` generated a working project layout and example tests
- `npx agent-qa validate tests/example-pass.yaml tests/hacker-news-top-story.yaml` validated both generated definitions

I did not install Chromium, configure a model provider, or run a complete browser flow during this check, so the PR does not claim that boundary was independently exercised.

## Validation

- `git diff --check`
- README and `llms.txt` descriptions and flags are synchronized
- the new README and `llms.txt` links resolve to the tracked `mcp/agent-qa.md` page in this branch

Disclosure: I am affiliated with Agent QA.
