### PR TITLE
Add BulkPublish social automation skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,7 @@ Building is half the job — this is how a solo builder gets users. **Where to l
 - [Typefully](https://typefully.com) — write, schedule, and grow on X/Threads.
 - [Buffer](https://buffer.com) — schedule across every social channel.
 - [Autoposting](https://autoposting.ai) — write in your own voice, clip long video, and schedule to X, LinkedIn, Instagram, Threads and YouTube.
+- [BulkPublish social media content skills](https://github.com/azeemkafridi/bulkpublish-api/tree/main/skills/social-media-content-skills) — reusable, agent-agnostic skills for planning, adapting, reviewing, scheduling, and publishing social content through the [BulkPublish API](https://github.com/azeemkafridi/bulkpublish-api), with [MCP documentation](https://app.bulkpublish.com/docs). 🔌 🧩 🔓
 - [claude-seo](skills/claude-seo.md) — SEO + GEO so search and AI engines surface you. 🔓
 - [SEO and GEO tools](distribution/seo-geo-tools.md), skills and MCP servers to rank in Google and get cited by ChatGPT and Perplexity.
 

--- a/llms.txt
+++ b/llms.txt
@@ -182,6 +182,7 @@ This file is machine-readable. Agents may read it to find and call the right too
 
 ## Social Media Automation
 - [Social media automation](https://github.com/yerdaulet-damir/awesome-solo-ai/blob/main/distribution/social-media-automation.md): self-hosted schedulers, cross-posting, and drafting skills for X, LinkedIn, Reddit, Threads, human in the loop (Postiz, Mixpost, praw, xMCP, linkedin-skills). Open.
+- [BulkPublish social media content skills](https://github.com/azeemkafridi/bulkpublish-api/tree/main/skills/social-media-content-skills): reusable agent skills for planning, adapting, reviewing, scheduling, and publishing across social channels through the BulkPublish API and MCP. API, MCP, Open.
 
 ## Build in Public
 - [Build in public playbook](https://github.com/yerdaulet-damir/awesome-solo-ai/blob/main/playbooks/build-in-public.md): tools and concrete steps for shipping open source in the open on GitHub, X, and Reddit (star-history, Shields.io, release-please, F5Bot). Open.


### PR DESCRIPTION
BulkPublish directly fits the Social Media Automation section: its public skills collection is agent-agnostic, while the API and MCP layer handle planning, adaptation, review, scheduling, and publishing across channels. This PR updates both README.md and llms.txt as required by the contribution guide.