### PR TITLE
Add YYLO

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,7 @@ Give your agent a persistent brain beyond the codebase. **→ Full pages in [`me
 - [Cline](https://github.com/cline/cline) — open-source autonomous coding agent for VS Code. 🔓
 - [Aider](https://aider.chat) — AI pair programming in your terminal. 🔓
 - [Better Agent](https://github.com/ofekron/better-agent) — local web workspace for Claude, Codex, and Gemini coding-agent sessions with delegation, parallel forks, approvals, and restart recovery. 🆓
+- [YYLO](https://github.com/yylo-dev/yylo) — command-line orchestrator for coding agents with typed task, validation, merge, and release-readiness boundaries; each task runs in a dedicated branch/worktree behind a risk-based merge queue. 🔓 🆓
 
 ## Automation & Agent Frameworks
 

--- a/llms.txt
+++ b/llms.txt
@@ -102,6 +102,7 @@ This file is machine-readable. Agents may read it to find and call the right too
 - [Cline](https://github.com/cline/cline): open-source autonomous coding agent. Open.
 - [Aider](https://aider.chat): terminal AI pair programming. Open.
 - [Better Agent](https://github.com/ofekron/better-agent): local web workspace for Claude, Codex, and Gemini coding-agent sessions, delegation, parallel forks, approvals, restart recovery. Free.
+- [YYLO](https://github.com/yylo-dev/yylo): command-line orchestrator for coding agents, typed task, validation, merge, and release-readiness boundaries, dedicated branch/worktree per task, risk-based merge queue. Open, Free.
 
 ## Automation & Agent Frameworks
 - [n8n](https://n8n.io): open-source workflow automation with AI nodes. Open.


### PR DESCRIPTION
## What this adds

One entry for **YYLO**, appended to `## AI Coding Agents` in both `README.md` and `llms.txt` (kept in sync per the contributing rules):

> YYLO — command-line orchestrator for coding agents with typed task, validation, merge, and release-readiness boundaries; each task runs in a dedicated branch/worktree behind a risk-based merge queue. 🔓 🆓

## Why it fits this section

- YYLO is a single-user CLI that orchestrates existing terminal coding agents (Pi and Codex subagents) — no team required, which matches the solo-builder framing.
- It sits beside **Better Agent** (local web workspace for Claude/Codex/Gemini sessions with delegation and parallel forks): YYLO is the terminal-native analogue — `task start` freezes the target SHA and runs each task in a dedicated branch/worktree, with a risk-based merge queue and receipt-backed runs instead of unbounded agent loops.
- Capability flags are accurate per the legend: 🔓 open source (MIT) and 🆓 free — no API flag and no MCP server, so neither is claimed.

## Disclosure

I'm on the team that builds YYLO (yylo-dev). This PR was prepared with an AI coding agent — fitting for a list designed to be fed to one. I use the tool daily; the description is taken from the project's README.

Repo: https://github.com/yylo-dev/yylo — 57★, MIT, npm [`@yylo/cli`](https://www.npmjs.com/package/@yylo/cli), in active daily development since January 2026.
